### PR TITLE
Settings UI, measure on keyDown, persistent measurement behavior

### DIFF
--- a/build.py
+++ b/build.py
@@ -3,7 +3,7 @@
 # -----------------
 
 name = "Laser Measure"
-version = "0.2"
+version = "0.4"
 developer = "Type Supply"
 developerURL = "http://typesupply.com"
 roboFontVersion = "4.2"

--- a/build/Laser Measure.roboFontExt/info.plist
+++ b/build/Laser Measure.roboFontExt/info.plist
@@ -38,7 +38,7 @@
 	<key>requiresVersionMinor</key>
 	<string>2</string>
 	<key>timeStamp</key>
-	<real>1686404272.1304309</real>
+	<real>1688142115.130441</real>
 	<key>version</key>
 	<string>0.2</string>
 </dict>

--- a/build/Laser Measure.roboFontExt/info.plist
+++ b/build/Laser Measure.roboFontExt/info.plist
@@ -38,7 +38,7 @@
 	<key>requiresVersionMinor</key>
 	<string>2</string>
 	<key>timeStamp</key>
-	<real>1688142115.130441</real>
+	<real>1688143737.0514669</real>
 	<key>version</key>
 	<string>0.2</string>
 </dict>

--- a/build/Laser Measure.roboFontExt/info.plist
+++ b/build/Laser Measure.roboFontExt/info.plist
@@ -38,7 +38,7 @@
 	<key>requiresVersionMinor</key>
 	<string>2</string>
 	<key>timeStamp</key>
-	<real>1688143737.0514669</real>
+	<real>1688144874.8455832</real>
 	<key>version</key>
 	<string>0.2</string>
 </dict>

--- a/build/Laser Measure.roboFontExt/info.plist
+++ b/build/Laser Measure.roboFontExt/info.plist
@@ -38,8 +38,8 @@
 	<key>requiresVersionMinor</key>
 	<string>2</string>
 	<key>timeStamp</key>
-	<real>1688144874.8455832</real>
+	<real>1728065714.6973948</real>
 	<key>version</key>
-	<string>0.2</string>
+	<string>0.4</string>
 </dict>
 </plist>

--- a/build/Laser Measure.roboFontExt/lib/laserMeasure/settingsWindow.py
+++ b/build/Laser Measure.roboFontExt/lib/laserMeasure/settingsWindow.py
@@ -22,14 +22,14 @@ class _LaserMeasureSettingsWindowController(ezui.WindowController):
         content = """
         = TwoColumnForm
 
+        !§ Laser
+
         : Trigger Character:
         [__]                                        @triggerCharacter
 
         : Text Size:
         [__] points                                 @measurementTextSize
-
-        !§ Laser
-
+        
         : Measure:
         [ ] Selected Points                         @testSelection
         [ ] General                                 @testGeneral
@@ -38,23 +38,31 @@ class _LaserMeasureSettingsWindowController(ezui.WindowController):
         [ ] Points                                  @testPoints
         [ ] Anchors                                 @testAnchors
 
-        ---
-
         : Color:
         * ColorWell                                 @baseColor
 
-        ####################
+        !§ Locked Measurements
 
-        !§ Highlight
+        : Show:
+        [ ]                                         @showPersistentMeasurements
 
-        : Hover-Match:
+        : Opacity:
+        --X--                                       @persistentMeasurementsOpacity
+
+        : Width:
+        [__] pixels                                 @persistentMeasurementsStrokeWidth
+        
+        : Color:
+        * ColorWell                                 @persistentMeasurementsColor
+
+        !§ Highlighted Matches
+
+        : Match:
         [ ] Segments                                @testSegmentMatches
         [ ] Off Curve Handles                       @testOffCurveMatches
 
         : Auto-Match:
         [ ] Segments                                @autoTestSegmentMatches
-
-        ---
 
         : Opacity:
         --X--                                       @highlightOpacity
@@ -62,43 +70,25 @@ class _LaserMeasureSettingsWindowController(ezui.WindowController):
         : Width:
         [__] pixels                                 @highlightStrokeWidth
 
-        : Animate:
+        : Pulse-Animate Matches:
         [ ]                                         @highlightAnimate
-        : Animation Duration:
+        : Pulse Speed:
         [__] seconds                                @highlightAnimationDuration
 
-        ####################
-
-        !§ Persistent Measurements
-
+        !§ Named Values HUD
+        
         : Show:
-        [ ]                                         @showPersistentMeasurements
-
-        ---
-
-        : Color:
-        * ColorWell                                 @persistentMeasurementsColor
-
-        : Opacity:
-        --X--                                       @persistentMeasurementsOpacity
-
-        : Width:
-        [__] pixels                                 @persistentMeasurementsStrokeWidth
-
-        ####################
-
-        !§ HUD
-
-        : Show Named Values List:
         [ ]                                         @showMeasurementsHUD
         """
         colorWellWidth = 100
         colorWellHeight = 20
         numberEntryWidth = 40
+        formTitleColumnWidth = 150
+        formItemColumnWidth = 180
         descriptionData = dict(
             content=dict(
-                titleColumnWidth=160,
-                itemColumnWidth=220
+                titleColumnWidth=formTitleColumnWidth,
+                itemColumnWidth=formItemColumnWidth
             ),
             testSelection=dict(
                 value=internalGetDefault("testSelection")
@@ -212,6 +202,7 @@ class _LaserMeasureSettingsWindowController(ezui.WindowController):
             if existing == value:
                 continue
             internalSetDefault(key, value)
+            # print(key, value)
         postEvent(
             extensionID + ".defaultsChanged"
         )

--- a/build/Laser Measure.roboFontExt/lib/laserMeasure/subscriber.py
+++ b/build/Laser Measure.roboFontExt/lib/laserMeasure/subscriber.py
@@ -328,11 +328,13 @@ class LaserMeasureSubscriber(subscriber.Subscriber):
             "extensionDefaultsChanged",
             extensionID + ".defaultsChanged"
         )
+        
+        self.point = (0,0)
         # go
         self.clearText()
         self.loadNamedMeasurements()
         self.loadDefaults()
-
+        
     def loadDefaults(self):
         # load
         self.showMeasurementsHUD = internalGetDefault("showMeasurementsHUD")
@@ -540,6 +542,9 @@ class LaserMeasureSubscriber(subscriber.Subscriber):
             if self.showMeasurementsHUD:
                 self.hud.show(self.currentSelectionMeasurements is not None)
             self.textContainer.setVisible(True)
+            
+            # Start measuring now
+            self.initiateLaser(self.point, glyph, deviceState)
 
     def glyphEditorDidKeyUp(self, info):
         if "deviceState" not in info:
@@ -567,17 +572,19 @@ class LaserMeasureSubscriber(subscriber.Subscriber):
         setCursorMode(None)
 
     # glyphEditorDidMouseMoveDelay = 0.05
-
     def glyphEditorDidMouseMove(self, info):
+        self.point = tuple(info["locationInGlyph"])
+        deviceState = info["deviceState"]
+        glyph = info["glyph"]
+        self.initiateLaser(self.point, glyph, deviceState)
+        
+    def initiateLaser(self, point, glyph, deviceState):
         if not self.wantsMeasurements:
             return
         self.selectionMeasurementsTextLayer.setVisible(False)
-        glyph = info["glyph"]
         if not glyph.bounds:
             self.hideLayers()
             return
-        deviceState = info["deviceState"]
-        point = tuple(info["locationInGlyph"])
         self.currentDisplayFocalPoint = point
         self.currentMeasurements = None
         anchorState = False

--- a/build/Laser Measure.roboFontExt/lib/laserMeasure/subscriber.py
+++ b/build/Laser Measure.roboFontExt/lib/laserMeasure/subscriber.py
@@ -128,8 +128,14 @@ def removePersistentPointMeasurementReferences(glyph, points):
         return
     identifiers = _getPointIdentifiers(points)
     existing = glyph.lib[persistentPointsKey]
-    if identifiers in existing:
-        existing.remove(identifiers)
+
+    pairs_to_remove = set()
+    for pair in existing:
+        if pair[0] in identifiers and pair[1] in identifiers:
+            pairs_to_remove.add(pair)
+    for pair in pairs_to_remove:
+        existing.remove(pair)
+
     if existing:
         glyph.lib[persistentPointsKey] = existing
     else:
@@ -1168,7 +1174,11 @@ class LaserMeasureSubscriber(subscriber.Subscriber):
         self.updatePersistentMeasurements(glyph)
 
     def breakPersistentMeasurements(self, glyph, deviceState):
+        # If removing measurements on selected points
         points = getSelectedPoints(glyph)
+        # But if no points are selected, remove all measurements
+        if not points:
+            points = [point for contour in glyph.contours for point in contour.points]
         removePersistentPointMeasurementReferences(glyph, points)
         self.needPersistentMeasurementsRebuild = True
         self.updatePersistentMeasurements(glyph)

--- a/source/code/laserMeasure/settingsWindow.py
+++ b/source/code/laserMeasure/settingsWindow.py
@@ -22,14 +22,14 @@ class _LaserMeasureSettingsWindowController(ezui.WindowController):
         content = """
         = TwoColumnForm
 
+        !§ Laser
+
         : Trigger Character:
         [__]                                        @triggerCharacter
 
         : Text Size:
         [__] points                                 @measurementTextSize
-
-        !§ Laser
-
+        
         : Measure:
         [ ] Selected Points                         @testSelection
         [ ] General                                 @testGeneral
@@ -38,23 +38,31 @@ class _LaserMeasureSettingsWindowController(ezui.WindowController):
         [ ] Points                                  @testPoints
         [ ] Anchors                                 @testAnchors
 
-        ---
-
         : Color:
         * ColorWell                                 @baseColor
 
-        ####################
+        !§ Locked Measurements
 
-        !§ Highlight
+        : Show:
+        [ ]                                         @showPersistentMeasurements
 
-        : Hover-Match:
+        : Opacity:
+        --X--                                       @persistentMeasurementsOpacity
+
+        : Width:
+        [__] pixels                                 @persistentMeasurementsStrokeWidth
+        
+        : Color:
+        * ColorWell                                 @persistentMeasurementsColor
+
+        !§ Highlighted Matches
+
+        : Match:
         [ ] Segments                                @testSegmentMatches
         [ ] Off Curve Handles                       @testOffCurveMatches
 
         : Auto-Match:
         [ ] Segments                                @autoTestSegmentMatches
-
-        ---
 
         : Opacity:
         --X--                                       @highlightOpacity
@@ -62,43 +70,25 @@ class _LaserMeasureSettingsWindowController(ezui.WindowController):
         : Width:
         [__] pixels                                 @highlightStrokeWidth
 
-        : Animate:
+        : Pulse-Animate Matches:
         [ ]                                         @highlightAnimate
-        : Animation Duration:
+        : Pulse Speed:
         [__] seconds                                @highlightAnimationDuration
 
-        ####################
-
-        !§ Persistent Measurements
-
+        !§ Named Values HUD
+        
         : Show:
-        [ ]                                         @showPersistentMeasurements
-
-        ---
-
-        : Color:
-        * ColorWell                                 @persistentMeasurementsColor
-
-        : Opacity:
-        --X--                                       @persistentMeasurementsOpacity
-
-        : Width:
-        [__] pixels                                 @persistentMeasurementsStrokeWidth
-
-        ####################
-
-        !§ HUD
-
-        : Show Named Values List:
         [ ]                                         @showMeasurementsHUD
         """
         colorWellWidth = 100
         colorWellHeight = 20
         numberEntryWidth = 40
+        formTitleColumnWidth = 150
+        formItemColumnWidth = 180
         descriptionData = dict(
             content=dict(
-                titleColumnWidth=160,
-                itemColumnWidth=220
+                titleColumnWidth=formTitleColumnWidth,
+                itemColumnWidth=formItemColumnWidth
             ),
             testSelection=dict(
                 value=internalGetDefault("testSelection")
@@ -212,6 +202,7 @@ class _LaserMeasureSettingsWindowController(ezui.WindowController):
             if existing == value:
                 continue
             internalSetDefault(key, value)
+            # print(key, value)
         postEvent(
             extensionID + ".defaultsChanged"
         )

--- a/source/code/laserMeasure/subscriber.py
+++ b/source/code/laserMeasure/subscriber.py
@@ -328,11 +328,13 @@ class LaserMeasureSubscriber(subscriber.Subscriber):
             "extensionDefaultsChanged",
             extensionID + ".defaultsChanged"
         )
+        
+        self.point = (0,0)
         # go
         self.clearText()
         self.loadNamedMeasurements()
         self.loadDefaults()
-
+        
     def loadDefaults(self):
         # load
         self.showMeasurementsHUD = internalGetDefault("showMeasurementsHUD")
@@ -540,6 +542,9 @@ class LaserMeasureSubscriber(subscriber.Subscriber):
             if self.showMeasurementsHUD:
                 self.hud.show(self.currentSelectionMeasurements is not None)
             self.textContainer.setVisible(True)
+            
+            # Start measuring now
+            self.initiateLaser(self.point, glyph, deviceState)
 
     def glyphEditorDidKeyUp(self, info):
         if "deviceState" not in info:
@@ -567,17 +572,19 @@ class LaserMeasureSubscriber(subscriber.Subscriber):
         setCursorMode(None)
 
     # glyphEditorDidMouseMoveDelay = 0.05
-
     def glyphEditorDidMouseMove(self, info):
+        self.point = tuple(info["locationInGlyph"])
+        deviceState = info["deviceState"]
+        glyph = info["glyph"]
+        self.initiateLaser(self.point, glyph, deviceState)
+        
+    def initiateLaser(self, point, glyph, deviceState):
         if not self.wantsMeasurements:
             return
         self.selectionMeasurementsTextLayer.setVisible(False)
-        glyph = info["glyph"]
         if not glyph.bounds:
             self.hideLayers()
             return
-        deviceState = info["deviceState"]
-        point = tuple(info["locationInGlyph"])
         self.currentDisplayFocalPoint = point
         self.currentMeasurements = None
         anchorState = False

--- a/source/code/laserMeasure/subscriber.py
+++ b/source/code/laserMeasure/subscriber.py
@@ -128,8 +128,14 @@ def removePersistentPointMeasurementReferences(glyph, points):
         return
     identifiers = _getPointIdentifiers(points)
     existing = glyph.lib[persistentPointsKey]
-    if identifiers in existing:
-        existing.remove(identifiers)
+
+    pairs_to_remove = set()
+    for pair in existing:
+        if pair[0] in identifiers and pair[1] in identifiers:
+            pairs_to_remove.add(pair)
+    for pair in pairs_to_remove:
+        existing.remove(pair)
+
     if existing:
         glyph.lib[persistentPointsKey] = existing
     else:
@@ -1168,7 +1174,11 @@ class LaserMeasureSubscriber(subscriber.Subscriber):
         self.updatePersistentMeasurements(glyph)
 
     def breakPersistentMeasurements(self, glyph, deviceState):
+        # If removing measurements on selected points
         points = getSelectedPoints(glyph)
+        # But if no points are selected, remove all measurements
+        if not points:
+            points = [point for contour in glyph.contours for point in contour.points]
         removePersistentPointMeasurementReferences(glyph, points)
         self.needPersistentMeasurementsRebuild = True
         self.updatePersistentMeasurements(glyph)


### PR DESCRIPTION
I think all should be stable, but the last commit is at the most risk of having broken something. In my quick testing, it appears to be working the way I envisioned. Comments in the code for you.

Another idea: should a simple trigger + click (no selection necessary be used to make or break persistent measurements? That might make the current extra persistence nicer, because the hand won't have to do gymnastics over the keyboard to make them.

@typesupply 